### PR TITLE
Catch errors opening the specified file

### DIFF
--- a/ConsoleApplication1/CrpDeserializer.cs
+++ b/ConsoleApplication1/CrpDeserializer.cs
@@ -6,14 +6,10 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ConsoleApplication1
 {
-    public class CrpDeserializer
+	public class CrpDeserializer
     {
         public string filePath;
         private FileStream stream;
@@ -21,15 +17,16 @@ namespace ConsoleApplication1
         private AssetParser assetParser;
         private Dictionary<string, int> typeRefCount = new Dictionary<string, int>();
 
-        public CrpDeserializer(string filePath)
+		/// <summary>
+		/// Initializes the object by opening the specified CRP file. Note and be prepared to handle the exceptions
+		/// that may be thrown.
+		/// </summary>
+		/// <param name="filePath">Path to the CRP file that needs to be opened.</param>
+		/// <exception cref="System.IO.IOException">Thrown if i.e the filePath parameter is incorrect, file is missing,
+		/// in use, etc.</exception>
+		public CrpDeserializer(string filePath)
         {
-			try { stream = File.Open(filePath, FileMode.Open); }
-			catch (IOException exception)
-			{
-				Console.WriteLine("An error was encountered while trying to open the file specified: " + exception.Message);
-				Console.ReadKey();
-				Environment.Exit(-1);
-			}
+			stream = File.Open(filePath, FileMode.Open);
             reader = new CrpReader(stream);
             assetParser = new AssetParser(reader);
         }

--- a/ConsoleApplication1/CrpDeserializer.cs
+++ b/ConsoleApplication1/CrpDeserializer.cs
@@ -23,7 +23,13 @@ namespace ConsoleApplication1
 
         public CrpDeserializer(string filePath)
         {
-            stream = File.Open(filePath, FileMode.Open);
+			try { stream = File.Open(filePath, FileMode.Open); }
+			catch (IOException exception)
+			{
+				Console.WriteLine("An error was encountered while trying to open the file specified: " + exception.Message);
+				Console.ReadKey();
+				Environment.Exit(-1);
+			}
             reader = new CrpReader(stream);
             assetParser = new AssetParser(reader);
         }

--- a/ConsoleApplication1/Program.cs
+++ b/ConsoleApplication1/Program.cs
@@ -1,16 +1,15 @@
 ﻿using CommandLine;
 using CrpParser;
+using System;
+using System.IO;
 
 namespace ConsoleApplication1
 {
-
-
-
 	class Program
     {
         static void Main(string[] args)
         {
-            var options = new Options();
+			var options = new Options();
 			/*#if DEBUG
 						options.Verbose = false;
 						options.SaveFiles = true;
@@ -23,18 +22,44 @@ namespace ConsoleApplication1
                 options.Verbose = false;
                 options.SaveFiles = true;
 
-                CrpDeserializer deserializer = new CrpDeserializer(options.InputFile);
-                deserializer.parseFile(options);
+				try
+				{
+					CrpDeserializer deserializer = new CrpDeserializer(options.InputFile);
+					deserializer.parseFile(options);
+				}
+				catch (IOException exception)
+				{
+					HardErrorToConsole(exception);
+				}
             }
 
             else if (Parser.Default.ParseArguments(args, options))
             {
-                CrpDeserializer deserializer = new CrpDeserializer(options.InputFile);
-                deserializer.parseFile(options);
-            }
+				try
+				{
+					CrpDeserializer deserializer = new CrpDeserializer(options.InputFile);
+					deserializer.parseFile(options);
+				}
+				catch (IOException exception)
+				{
+					HardErrorToConsole(exception);
+				}
+			}
+			//#endif
+		}
 
-//#endif
-
-        }
+		/// <summary>
+		/// Alerts the user to a fatal runtime error and terminates the program.
+		/// </summary>
+		/// <param name="exception">An Exception object containing additional information about the error.</param>
+		static void HardErrorToConsole(Exception exception)
+		{
+			Console.ForegroundColor = ConsoleColor.Red;
+			Console.Write("Error: ");
+			Console.ResetColor();
+			Console.WriteLine(exception.Message);
+			Console.ReadKey();
+			Environment.Exit(-1);
+		}
     }
 }

--- a/ConsoleApplication1/Program.cs
+++ b/ConsoleApplication1/Program.cs
@@ -1,30 +1,23 @@
 ﻿using CommandLine;
-using CommandLine.Text;
 using CrpParser;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Security;
-using System.Text;
 
 namespace ConsoleApplication1
 {
 
-    
 
-    class Program
+
+	class Program
     {
         static void Main(string[] args)
         {
             var options = new Options();
-#if DEBUG
-            options.Verbose = false;
-            options.SaveFiles = true;
-            CrpDeserializer deserializer = new CrpDeserializer("C:\\Program Files (x86)\\Steam\\steamapps\\workshop\\content\\255710\\721098648\\San Minato LUT V1.3.crp");
-             deserializer.parseFile(options);
-#else
-            if (args.Length == 1)
+			/*#if DEBUG
+						options.Verbose = false;
+						options.SaveFiles = true;
+						CrpDeserializer deserializer = new CrpDeserializer("C:\\Program Files (x86)\\Steam\\steamapps\\workshop\\content\\255710\\721098648\\San Minato LUT V1.3.crp");
+						 deserializer.parseFile(options);
+			#else*/
+			if (args.Length == 1)
             {
                 options.InputFile = args[0];
                 options.Verbose = false;
@@ -40,7 +33,7 @@ namespace ConsoleApplication1
                 deserializer.parseFile(options);
             }
 
-#endif
+//#endif
 
         }
     }

--- a/ConsoleApplication1/Properties/AssemblyInfo.cs
+++ b/ConsoleApplication1/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.3.7")]
+[assembly: AssemblyFileVersion("1.0.3.7")]


### PR DESCRIPTION
Handles things like typos and files that are in use by other programs. I noticed this was a problem when I tried debugging without changing the debug parameters. I also updated the assembly & file versions to be in line with what you have for your release versions, and then my extension was also bumping the build version while I was debugging. Hope this helps!